### PR TITLE
Bump Auspice to version 2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 0.6.0 (2021-06-01)
+
+* Upgraded auspice to 2.26.0
+
 ### Version 0.5.0 (2021-01-29)
 
 * Upgraded auspice to 2.23.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "auspice.us",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "auspice": "2.23.0",
+        "auspice": "2.26.0",
         "heroku-ssl-redirect": "0.0.4"
       },
       "devDependencies": {}
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/auspice": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.23.0.tgz",
-      "integrity": "sha512-V3ZYwEVFKKL8/0x4B9DtPHaujbwwuS7DNsQrzZkzY8mu6iQvLQ0M83GK7mvLwd9pUJ/5WtwZ7KuN+5rid8YFMg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.26.0.tgz",
+      "integrity": "sha512-UCqxEIXLUjYlM4FBsBJ8uspHCS1j4qk0fuJM/SadYkm0CHw3Y5F/aMUgFr+Yx3rSCY86o9Pe8URyoW6r/v/Dhw==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.3.4",
@@ -8226,10 +8226,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -10235,9 +10233,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "auspice": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.23.0.tgz",
-      "integrity": "sha512-V3ZYwEVFKKL8/0x4B9DtPHaujbwwuS7DNsQrzZkzY8mu6iQvLQ0M83GK7mvLwd9pUJ/5WtwZ7KuN+5rid8YFMg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.26.0.tgz",
+      "integrity": "sha512-UCqxEIXLUjYlM4FBsBJ8uspHCS1j4qk0fuJM/SadYkm0CHw3Y5F/aMUgFr+Yx3rSCY86o9Pe8URyoW6r/v/Dhw==",
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice.us",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "scripts": {
@@ -11,7 +11,7 @@
     "develop": "auspice develop --verbose --extend ./auspice_client_customisation/config.json --handlers ./server/handlers.js"
   },
   "dependencies": {
-    "auspice": "2.23.0",
+    "auspice": "2.26.0",
     "heroku-ssl-redirect": "0.0.4"
   },
   "devDependencies": {}


### PR DESCRIPTION
### Description of proposed changes    

Latest versions of Auspice support the new scatterplot layout that PHL users and other groups would like to use with their current drag-and-drop visualization workflow. This bumps auspice.us to the latest Auspice version.

### Testing

Tested this locally with the build commands in the README and loaded the ncov `getting_started` global JSON with no issues.