### PR TITLE
Stop error notifications for metadata files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 0.10.0 (2022-02-22)
+
+* Fixed misleading error notifications when dragging on metadata files ([PR 16](https://github.com/nextstrain/auspice.us/pull/16)).
+
 ### Version 0.9.0 (2022-02-22)
 
 * Upgraded auspice to 2.33.0

--- a/auspice_client_customisation/handleDroppedFiles.js
+++ b/auspice_client_customisation/handleDroppedFiles.js
@@ -1,5 +1,6 @@
 import { createStateFromQueryOrJSONs } from "@auspice/actions/recomputeReduxState";
-import { errorNotification } from "@auspice/actions/notifications";
+import { errorNotification, warningNotification } from "@auspice/actions/notifications";
+import { isAcceptedFileType as isAuspiceAcceptedFileType } from "@auspice/actions/filesDropped/constants";
 import newickToAuspiceJson from "./parseNewick";
 
 /* The following requires knowledge of how auspice works, is undocumented, and is liable to change since auspice
@@ -36,6 +37,17 @@ export const handleDroppedFiles = (dispatch, files) => {
       } else if (fileName.endsWith("new") || fileName.endsWith("nwk") || fileName.endsWith("newick")) {
         console.log("Parsing dropped file as a newick tree with branch lengths of divergence");
         json = newickToAuspiceJson(file.name, event.target.result);
+      /**
+       * Added as another `else if` statement after the checks for JSON and
+       * Newick files on the off chance that Auspice accepts these file types
+       * in the future. -Jover, 10 Dec 2021
+       */
+      } else if (isAuspiceAcceptedFileType(file)) {
+          console.log("Dropped metadata file cannot be parsed by auspice.us");
+          return dispatch(warningNotification({
+            message: "Failed to parse additional metadata file!",
+            details: "Please drop the additional metadata file after the tree has loaded."
+          }));
       } else {
         throw new Error("Parser for this file type not (yet) implemented");
       }

--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -7,14 +7,28 @@ import { version, dependencies } from "../package.json";
 class SplashContent extends React.Component {
   constructor(props) {
     super(props);
+    this.handleDrop = this.handleDrop.bind(this);
   }
   componentDidMount() {
-    document.addEventListener("dragover", (e) => {e.preventDefault();}, false);
-    document.addEventListener("drop", (e) => {
-      e.preventDefault();
-      handleDroppedFiles(this.props.dispatch, e.dataTransfer.files);
-    }, false);
+    document.addEventListener("dragover", this.handleDragover, false);
+    document.addEventListener("drop", this.handleDrop, false);
   }
+
+  componentWillUnmount() {
+    console.log("Removing auspice.us event listeners");
+    document.removeEventListener("dragover", this.handleDragover, false);
+    document.removeEventListener("drop", this.handleDrop, false);
+  }
+
+  handleDragover (event) {
+    event.preventDefault();
+  }
+
+  handleDrop (event) {
+    event.preventDefault();
+    handleDroppedFiles(this.props.dispatch, event.dataTransfer.files);
+  }
+
   datasetLink(path) {
     return (
       <div

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice.us",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice.us",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
Fixes #14.
~Stop the unexpected error notification for dragged on metadata files by
ignoring metadata files in `handleDroppedFiles` because these files are
ultimately handled by Auspice.~

See commit for details.
