### PR TITLE
Load sidecars and narratives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Version 0.11.0 (2022-02-22)
+
+Improved dataset loading functionality ([PR 23](https://github.com/nextstrain/auspice.us/pull/23)).
+* Sidecar files can now be loaded.
+* Two datasets can be loaded, but this functionality is not particularly useful as there is no way to order the trees.
+* A narrative (markdown) can be loaded, as long as they are dragged together with the datasets they reference.
+
+
 ### Version 0.10.0 (2022-02-22)
 
 * Fixed misleading error notifications when dragging on metadata files ([PR 16](https://github.com/nextstrain/auspice.us/pull/16)).

--- a/auspice_client_customisation/handleDroppedFiles.js
+++ b/auspice_client_customisation/handleDroppedFiles.js
@@ -136,10 +136,12 @@ async function collectDatasets(dispatch, files) {
  * @param {*} datasets 
  */
 async function loadDatasets(dispatch, datasets) {
-  if (Object.values(datasets).length > 1) {
-    console.log("Only loading the first dataset as auspice.us does not yet handle multiple datasets");
+  const datasetList = Object.values(datasets); // we have no sensible way of ordering these
+  if (datasetList.length > 2) {
+    console.log("Only loading the first two datasets");
   }
-  const dataset = Object.values(datasets)[0];
+  const dataset = datasetList[0];
+  const dataset2 = datasetList.length > 1 ? datasetList[1] : false;
 
   /* load (into redux state) the main dataset(s) */
   try {
@@ -147,11 +149,11 @@ async function loadDatasets(dispatch, datasets) {
       type: "CLEAN_START",
       ...createStateFromQueryOrJSONs({
         json: dataset.main,
-        secondTreeDataset: undefined,
+        secondTreeDataset: dataset2 ? dataset2.main : null,
         query: {},
         narrativeBlocks: undefined,
-        mainTreeName: Object.values(datasets)[0].name,
-        secondTreeName: null,
+        mainTreeName: dataset.name,
+        secondTreeName: dataset2 ? dataset2.name : null,
         dispatch
       })
     });

--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -103,9 +103,7 @@ class SplashContent extends React.Component {
           <Line/>
 
           <P>
-            {`auspice.us ${version} is built by `}<a href="https://twitter.com/hamesjadfield">james hadfield</a>
-            <br/>
-            {`and uses Auspice ${dependencies.auspice}.`}
+            {`auspice.us ${version} (Auspice ${dependencies.auspice})`}
           </P>
           <NextstrainTitle/>
           <GitHub/>

--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -67,13 +67,18 @@ class SplashContent extends React.Component {
 
         <CenterContent>
           <P>
-            Currently supported data formats:
+            Currently supported files:
             <ul>
-              <li>Auspice JSON - see the
-                <a href="https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json"> JSON schema </a>
-                and the
+              <li>Auspice datasets (a main JSON plus any sidecars). See the
                 <a href="https://nextstrain.org/docs/bioinformatics/introduction-to-augur"> Nextstrain docs </a>
-                for how to run the bioinformatics tools to generate these datasets
+                for how to run the bioinformatics tools to generate these datasets.
+                Note that it's possible to drag on multiple datasets, however at most two will be loaded, and it's not possible to control the ordering of these datasets!
+              </li>
+              <li>A nextstrain narrative and associated datasets (JSONs) - see the
+                <a href="https://docs.nextstrain.org/en/latest/tutorials/narratives-how-to-write.html"> Nextstrain docs </a>
+                for how author a narrative. Each dataset the narrative references should have a filename which is the
+                <a href="https://en.wikipedia.org/wiki/URL"> URL path</a> but with forward slashes replaced with underscores ("/"→"_") and a ".json" suffix.
+                Only one narrative can be dropped on at a time!
               </li>
               <li>
                 A phylogenetic tree in

--- a/auspice_client_customisation/styles.js
+++ b/auspice_client_customisation/styles.js
@@ -1,6 +1,5 @@
 import React from "react"; // eslint-disable-line
 import styled from 'styled-components';
-import { version } from "../package.json";
 const logoPNG = require("./nextstrain-logo-small.png");
 const gitHubLogo = require("./GitHub-Mark-32px.png");
 
@@ -17,11 +16,14 @@ export const Title = styled.p`
   background-color: #30353f;
 `;
 
-export const P = styled.p`
-  text-align: center;
-  padding: 0px 20px 15px 20px;
-  font-weight: 300;
-  color: #30353f;
+export const P = styled.div`
+  &&& {
+    text-align: center;
+    margin: 16px 0px;
+    padding: 0px 20px 15px 20px;
+    font-weight: 300;
+    color: #30353f;
+  }
 `;
 
 export const Bold = styled.span`

--- a/auspice_client_customisation/styles.js
+++ b/auspice_client_customisation/styles.js
@@ -23,6 +23,9 @@ export const P = styled.div`
     padding: 0px 20px 15px 20px;
     font-weight: 300;
     color: #30353f;
+    & > ul > li {
+      padding-bottom: 10px;
+    }
   }
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "auspice": "2.34.0",
+        "auspice": "2.34.1",
         "heroku-ssl-redirect": "0.0.4"
       }
     },
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/auspice": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.34.0.tgz",
-      "integrity": "sha512-zY872eCmb7kSos6RhTV4vSaI0QFBggZ2Wz+HN9nETAizokICIfCioPJSnuzzA3iyP/Yf/olAaqqiB0IQy1eeDA==",
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.34.1.tgz",
+      "integrity": "sha512-U5IdKdIh0rTp5KMbY7ddv87UN66lTrVvkegB3lmXEZ10wC55sSKMnqzHBz7GpKsGzCcmlBH/ZkCHyomFuxbV6g==",
       "dependencies": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -10225,9 +10225,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "auspice": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.34.0.tgz",
-      "integrity": "sha512-zY872eCmb7kSos6RhTV4vSaI0QFBggZ2Wz+HN9nETAizokICIfCioPJSnuzzA3iyP/Yf/olAaqqiB0IQy1eeDA==",
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.34.1.tgz",
+      "integrity": "sha512-U5IdKdIh0rTp5KMbY7ddv87UN66lTrVvkegB3lmXEZ10wC55sSKMnqzHBz7GpKsGzCcmlBH/ZkCHyomFuxbV6g==",
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auspice.us",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auspice.us",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice.us",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "develop": "auspice develop --verbose --extend ./auspice_client_customisation/config.json --handlers ./server/handlers.js"
   },
   "dependencies": {
-    "auspice": "2.34.0",
+    "auspice": "2.34.1",
     "heroku-ssl-redirect": "0.0.4"
   }
 }


### PR DESCRIPTION
See commit messages for details. I’ll post a tarball of files used for testing this on slack. 

The measurements sidecar failed to load, which seemed on the surface to be an auspice error (not auspice.us). We can make this a separate issue perhaps?

Closes #7
Closes #20

