### PR TITLE
Check for auspice updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "auspice"


### PR DESCRIPTION
### Description of proposed changes

Uses dependabot to check for auspice updates.

### Related issue(s)

- #31
    - To fully close this issue, we would need a GitHub Actions workflow to auto-merge these PRs ([I've done this with serratus.io](https://github.com/serratus-bio/serratus.io/blob/2ad2a2dba2b0a8ac90bb5634d0afec5b4aa7bfbe/.github/workflows/dependabot-auto-merge.yml)).

### Testing

- [x] Created this commit on a fork repo and verified an auto-bump PR was created: https://github.com/victorlin/auspice.us/pull/1
    - Note that there's also a nice log for these checks: https://github.com/victorlin/auspice.us/network/updates