### PR TITLE
Use app.json, upgrade to `heroku-22`

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,5 +17,5 @@
       "url": "heroku/nodejs"
     }
   ],
-  "stack": "heroku-18"
+  "stack": "heroku-22"
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "auspice.us",
+  "scripts": {},
+  "env": {
+    "HOST": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ],
+  "stack": "heroku-18"
+}

--- a/app.json
+++ b/app.json
@@ -3,7 +3,8 @@
   "scripts": {},
   "env": {
     "HOST": {
-      "required": true
+      "description": "For Auspice server; see https://docs.nextstrain.org/projects/auspice/en/stable/server/index.html#deploying-via-heroku",
+      "value": "0.0.0.0"
     }
   },
   "formation": {


### PR DESCRIPTION
### Description of proposed changes

Create an app.json and use it to upgrade the Heroku stack to `heroku-22`.

### Related issue(s)

_N/A_

### Testing

- [x] [Review app builds with `heroku-22`](https://dashboard.heroku.com/apps/auspice-us-victorlin-up-1h23mw/activity/builds/57ef26fc-bcda-4c24-88a4-243ae470a705)