### PR TITLE
Specify Node version 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
       "dependencies": {
         "auspice": "2.39.0",
         "heroku-ssl-redirect": "0.0.4"
+      },
+      "engines": {
+        "node": "16.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.12.0",
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
+  "engines": {
+    "node": "16.x"
+  },
   "scripts": {
     "modify-auspice-server": "node scripts/modify-auspice-server.js",
     "postinstall": "npm run modify-auspice-server",


### PR DESCRIPTION
### Description of proposed changes

It's recommended to set the Node version explicitly¹, otherwise the build server chooses a default which can change unexpectedly. For example, this change was prompted because Heroku recently switched from 16 to 18. Auspice doesn't work on 18 yet², so we need to use 16.

¹ https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
² https://github.com/nextstrain/auspice/issues/1553

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

_N/A_

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually inspect Heroku build log ([ref](https://github.com/nextstrain/auspice.us/pull/40#discussion_r1002066648))
- [x] Preview app opens

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
