### PR TITLE
Use default export to avoid Webpack 5 warning

### DIFF
--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -1,7 +1,7 @@
 import React from "react"; // eslint-disable-line
 import { handleDroppedFiles } from "./handleDroppedFiles";
 import { P, Bold, Title, NextstrainTitle, CenterContent, Line, GitHub } from './styles';
-import { version, dependencies } from "../package.json";
+import pkg from "../package.json";
 
 
 class SplashContent extends React.Component {
@@ -108,7 +108,7 @@ class SplashContent extends React.Component {
           <Line/>
 
           <P>
-            {`auspice.us ${version} (Auspice ${dependencies.auspice})`}
+            {`auspice.us ${pkg.version} (Auspice ${pkg.dependencies.auspice})`}
           </P>
           <NextstrainTitle/>
           <GitHub/>


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

In Webpack 5, named exports from JSON modules are no longer supported¹.

This is in anticipation of Auspice using Webpack 5 in a future release, but it should be compatible with the current release.

¹ https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- In anticipation of https://github.com/nextstrain/auspice/pull/1520

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
