### PR TITLE
Upgrade to Node.js 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "heroku-ssl-redirect": "0.0.4"
       },
       "engines": {
-        "node": "16.x"
+        "node": "^16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "heroku-ssl-redirect": "0.0.4"
       },
       "engines": {
-        "node": "^16"
+        "node": "^18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "engines": {
-    "node": "^16"
+    "node": "^18"
   },
   "scripts": {
     "modify-auspice-server": "node scripts/modify-auspice-server.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "engines": {
-    "node": "16.x"
+    "node": "^16"
   },
   "scripts": {
     "modify-auspice-server": "node scripts/modify-auspice-server.js",


### PR DESCRIPTION
### Description of proposed changes

Node.js 16 will reach EOL on 2023-09-11¹. Node.js 18 is the next LTS version, with projected EOL on 2025-04-30.

¹ https://github.com/nodejs/Release/blob/6a881a11363eb601f17b2d46e3f1664db5ce2a3b/README.md

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
