### PR TITLE
Bump Node.js version from 16 to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version-file: 'package.json'
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "heroku-ssl-redirect": "0.0.4"
       },
       "engines": {
-        "node": "16.x"
+        "node": "20.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "engines": {
-    "node": "16.x"
+    "node": "20.x"
   },
   "scripts": {
     "modify-auspice-server": "node scripts/modify-auspice-server.js",


### PR DESCRIPTION
Keeping up to date. nextstrain.org is getting the same treatment in https://github.com/nextstrain/nextstrain.org/pull/810

Closes #61 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] CI uses Node.js 20
- [x] Heroku preview build uses Node.js 20

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
