### PR TITLE
[DO NOT MERGE] Revert "Bump auspice from 2.56.1 to 2.57.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "auspice": "2.57.0",
+        "auspice": "2.56.1",
         "heroku-ssl-redirect": "0.0.4"
       },
       "engines": {
@@ -2572,9 +2572,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/auspice": {
-      "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.57.0.tgz",
-      "integrity": "sha512-PJg6LYaZ0SRAZHBB3SjMZ+cKLcTacEwHV5dgnFn8JdiK35IVjBzPiP5vS+/riZ09W7JdxjVR1pmUZcSZkz/c5Q==",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.56.1.tgz",
+      "integrity": "sha512-dnXcBePMoW2U2jc0gDdIBk8jXa9gPtIe+oKHiwiJOf1bJfBt2uRAFE+VUUOdaxe31iZlZAxnSUW7fSHsfZxGyA==",
       "dependencies": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -9682,9 +9682,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "auspice": {
-      "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.57.0.tgz",
-      "integrity": "sha512-PJg6LYaZ0SRAZHBB3SjMZ+cKLcTacEwHV5dgnFn8JdiK35IVjBzPiP5vS+/riZ09W7JdxjVR1pmUZcSZkz/c5Q==",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.56.1.tgz",
+      "integrity": "sha512-dnXcBePMoW2U2jc0gDdIBk8jXa9gPtIe+oKHiwiJOf1bJfBt2uRAFE+VUUOdaxe31iZlZAxnSUW7fSHsfZxGyA==",
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "develop": "auspice develop --verbose --extend ./auspice_client_customisation/config.json --handlers ./server/handlers.js"
   },
   "dependencies": {
-    "auspice": "2.57.0",
+    "auspice": "2.56.1",
     "heroku-ssl-redirect": "0.0.4"
   }
 }


### PR DESCRIPTION
This reverts commit 2a7f990cc9126b15affeaa8aa0abf45fd597701b.

Workaround for https://github.com/nextstrain/auspice/issues/1844