### PR TITLE
handleDroppedFiles: Don't show error notification for `.md` files

### DIFF
--- a/auspice_client_customisation/handleDroppedFiles.js
+++ b/auspice_client_customisation/handleDroppedFiles.js
@@ -110,7 +110,7 @@ async function collectDatasets(dispatch, files) {
     const nameLower = file.name.toLowerCase();
     if (filesSeen.has(nameLower)) continue;
 
-    if (!nameLower.endsWith("json")) {
+    if (!nameLower.endsWith("json") && !nameLower.endsWith(".md")) {
       dispatch(errorNotification({
         message: `Failed to load ${file.name}.`,
         details: "Please refer to the homepage for supported files, and check that your file is named properly."

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "auspice": "2.59.1",
+        "auspice": "2.60.0",
         "heroku-ssl-redirect": "0.0.4"
       },
       "engines": {
@@ -2572,9 +2572,10 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/auspice": {
-      "version": "2.59.1",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.59.1.tgz",
-      "integrity": "sha512-JdfCQ2waAY/BPeIZ58tAUIYWwopY28FuQ3JjG+esa5fPbp5+Ovbx4rl6LqWCscohyojdxgJvJX4l8a1Av2b9ZA==",
+      "version": "2.60.0",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.60.0.tgz",
+      "integrity": "sha512-2kzfVOiO3h4jjKUlF8vWhyty8UBUoWVP1ES3G65C3XN/0q9xVHHyBH5xHz7KXW4i5MuoUre8xPxVgm9L7+AOxQ==",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",
@@ -9682,9 +9683,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "auspice": {
-      "version": "2.59.1",
-      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.59.1.tgz",
-      "integrity": "sha512-JdfCQ2waAY/BPeIZ58tAUIYWwopY28FuQ3JjG+esa5fPbp5+Ovbx4rl6LqWCscohyojdxgJvJX4l8a1Av2b9ZA==",
+      "version": "2.60.0",
+      "resolved": "https://registry.npmjs.org/auspice/-/auspice-2.60.0.tgz",
+      "integrity": "sha512-2kzfVOiO3h4jjKUlF8vWhyty8UBUoWVP1ES3G65C3XN/0q9xVHHyBH5xHz7KXW4i5MuoUre8xPxVgm9L7+AOxQ==",
       "requires": {
         "@babel/core": "^7.3.4",
         "@babel/plugin-proposal-class-properties": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "develop": "auspice develop --verbose --extend ./auspice_client_customisation/config.json --handlers ./server/handlers.js"
   },
   "dependencies": {
-    "auspice": "2.59.1",
+    "auspice": "2.60.0",
     "heroku-ssl-redirect": "0.0.4"
   }
 }


### PR DESCRIPTION
## Description of proposed changes

Noticed the bug while testing out changes in https://github.com/nextstrain/auspice.us/pull/107. 

Fixes bug where all narrative `.md` files triggered the error notification that the file failed to load.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
