### PR TITLE
Support .json.gz files

### DIFF
--- a/auspice_client_customisation/handleDroppedFiles.js
+++ b/auspice_client_customisation/handleDroppedFiles.js
@@ -22,7 +22,7 @@ export const handleDroppedFiles = async (dispatch, files) => {
 };
 
 /** promisify FileReader's readAsText() so we can use it within
- * async functions via `await readJson(file)`.
+ * async functions via `await readFile(file)`.
  * Adapted from https://stackoverflow.com/a/51026615
  */
 function readFile(file, isJSON=true) {

--- a/auspice_client_customisation/handleDroppedFiles.js
+++ b/auspice_client_customisation/handleDroppedFiles.js
@@ -25,11 +25,11 @@ export const handleDroppedFiles = async (dispatch, files) => {
  * async functions via `await readFile(file)`.
  * Adapted from https://stackoverflow.com/a/51026615
  */
-function readFile(file, isJSON=true) {
+function readFile(file) {
   return new Promise((resolve, reject) => {
     const fileReader = new window.FileReader();
     fileReader.onloadend = function(e) {
-      if (isJSON) {
+      if (file.name.toLowerCase().endsWith(".json")) {
         const json = JSON.parse(e.target.result);
         resolve(json);
       } else {
@@ -88,7 +88,7 @@ async function collectDatasets(dispatch, files) {
       try {
         const d = new Dataset(file.name);
         d.apiCalls = {}; // ensures no prototypes mistakenly make api calls
-        d.main = newickToAuspiceJson(file.name, await readFile(file, false));
+        d.main = newickToAuspiceJson(file.name, await readFile(file));
         datasets[nameLower] = d;
         logs.push(`Read ${file.name} as a newick file`);
       } catch (e) {
@@ -141,7 +141,7 @@ async function collectDatasets(dispatch, files) {
     if (nameLower.endsWith(".md")) {
       filesSeen.add(nameLower);
       logs.push(`Read ${file.name} as a narrative.`);
-      ({datasets, narrative} = await parseNarrative(await readFile(file, false), datasets, logs));
+      ({datasets, narrative} = await parseNarrative(await readFile(file), datasets, logs));
       break; // don't consider multiple markdown files
     }
   }

--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -67,7 +67,7 @@ const SplashContent = (props) => {
             <li>Auspice datasets (a main JSON plus any sidecars). See the
               <a href="https://nextstrain.org/docs/bioinformatics/introduction-to-augur"> Nextstrain docs </a>
               for how to run the bioinformatics tools to generate these datasets.
-              Note that it's possible to drag on multiple datasets, however at most two will be loaded, and it's not possible to control the ordering of these datasets!
+              Note that it's possible to drag on multiple datasets, however at most two will be loaded, and it's not possible to control the ordering of these datasets! Each JSON file can be uncompressed (<Bold>.json</Bold>) or gzip-compressed (<Bold>.json.gz</Bold>)
             </li>
             <li>A nextstrain narrative ending in <Bold>.md</Bold> and associated datasets (JSONs) - see the
               <a href="https://docs.nextstrain.org/en/latest/tutorials/narratives-how-to-write.html"> Nextstrain docs </a>


### PR DESCRIPTION
## Description of proposed changes

Auspice JSONs can be large, and in such cases they are often compressed using gzip. Adding the ability to load these files directly removes the need for users to manually decompress the file.

Done using the Compression Streams API¹.

¹ <https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API>

## Related issue(s)

Closes #112

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested locally with a manually created `zika.json.gz`
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
