### PR TITLE
Update splash docs

### DIFF
--- a/auspice_client_customisation/splash.js
+++ b/auspice_client_customisation/splash.js
@@ -85,8 +85,8 @@ const SplashContent = (props) => {
               <a href="https://en.wikipedia.org/wiki/Newick_format"> Newick format</a> with name ending in <Bold>.new</Bold>, <Bold>.nwk</Bold>, or <Bold>.newick</Bold>.
             </li>
             <li>
-              Additional metadata as a CSV/TSV (drop this on once the tree has loaded).
-              <a href="https://nextstrain.github.io/auspice/advanced-functionality/drag-drop-csv-tsv"> See here for details.</a>
+              Additional metadata file(s) in any of the
+              <a href="https://nextstrain.github.io/auspice/advanced-functionality/drag-drop-csv-tsv"> supported drag-and-drop file formats.</a>
             </li>
           </ul>
         </P>

--- a/auspice_client_customisation/styles.js
+++ b/auspice_client_customisation/styles.js
@@ -27,6 +27,10 @@ export const P = styled.div`
       padding-bottom: 10px;
     }
   }
+
+  li {
+    text-align: start;
+  }
 `;
 
 export const Bold = styled.span`
@@ -81,4 +85,3 @@ export const GitHub = () => (
     <span style={{fontWeight: 400, fontSize: "16px"}}>{" /nextstrain/auspice.us"}</span>
   </a>
 );
-


### PR DESCRIPTION
## Description of proposed changes

Update splash page docs to latest supported files. 
Includes small style change to stop centering list text.

<img width="2430" height="414" alt="Screenshot 2026-06-02 at 1 40 05 PM" src="https://github.com/user-attachments/assets/cb766848-a92a-4f67-8493-d51aabbe8790" />


## Related issue(s)

Follow up to https://github.com/nextstrain/auspice.us/pull/148
Prompted by testing for https://github.com/nextstrain/auspice/pull/2046

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
