### PR TITLE
Bump Node.js version to 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "James Hadfield",
   "license": "AGPL-3.0-only",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 .",


### PR DESCRIPTION
Keeping up to date. nextstrain.org is already using this version.

## Checklist

- [x] Checks pass
